### PR TITLE
Fix production Dockerfile, update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,18 @@ jobs:
       - name: Check-out repository
         uses: actions/checkout@v2
 
-      - name: Build Docker Image With Compose
+      # Check if the main dockerfile builds:
+      - name: Build "Production" Docker Image
         run: |
-          make action_compose_build
+          make build
 
-      - name: Run Docker Tests With Compose
+        # Check if the main dockerfile builds:
+      - name: Build "Development" Docker Image
         run: |
-          make action_compose_test
+          make build_dev
+
+      # TODO: Running containerized tests:
+      # - name: Run Docker Tests With Compose
+      #   run: |
+      #     make action_compose_test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as build_sc2_info_extractor
+FROM golang:1.21-alpine as build_sc2_info_extractor
 
 WORKDIR /sc2_info_extractor
 
@@ -15,8 +15,7 @@ RUN --mount=type=cache,target=/go go build
 
 FROM alpine:latest as final
 
-# libc6-compat is needed for the binary to run on Alpine Linux:
-RUN apk add --no-cache ca-certificates libc6-compat
+RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,13 @@ RUN --mount=type=cache,target=/go go build
 
 FROM alpine:latest as final
 
-RUN apk add --no-cache ca-certificates
+# libc6-compat is needed for the binary to run on Alpine Linux:
+RUN apk add --no-cache ca-certificates libc6-compat
 
-COPY --from=0 /sc2_info_extractor/SC2InfoExtractorGo .
+WORKDIR /app
 
-CMD ["./SC2InfoExtractorGo"]
+RUN mkdir logs
+
+COPY --from=0 /sc2_info_extractor/SC2InfoExtractorGo /app/
+
+ENTRYPOINT ["/app/SC2InfoExtractorGo"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:latest as build_sc2_info_extractor
+FROM golang:1.21-alpine as build_sc2_info_extractor
 
 WORKDIR /sc2-info-extractor
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM golang:1.21-alpine as build_sc2_info_extractor
 
-WORKDIR /sc2-info-extractor
+WORKDIR /sc2_info_extractor
 
 # Copy Golang dependency definitions:
 COPY go.mod go.sum /sc2_info_extractor/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all:
 		./SC2InfoExtractorGo -log_level 6
 
 build:
-	docker build --tag=sc2-info-extractor -f ./Dockerfile .
+	docker build --tag=sc2infoextractorgo -f ./Dockerfile .
 
 build_dev:
-	docker build --tag=sc2-info-extractor:dev -f ./Dockerfile.dev .
+	docker build --tag=sc2infoextractorgo:dev -f ./Dockerfile.dev .

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ all:
 
 build:
 	docker build --tag=sc2-info-extractor -f ./Dockerfile .
+
+build_dev:
+	docker build --tag=sc2-info-extractor:dev -f ./Dockerfile.dev .

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ all:
 		./SC2InfoExtractorGo -log_level 6
 
 build:
-	docker build . -t sc2-info-extractor
+	docker build --tag=sc2-info-extractor -f ./Dockerfile .

--- a/README.md
+++ b/README.md
@@ -6,7 +6,18 @@ This tool is meant to allow for quick data extraction from SC2 replay files ".SC
 
 ## Usage
 
-In order to use this tool please call ```SC2InfoExtractorGo.exe``` and set the choosen flags listed below:
+The easiest way to run this tool is to use the provided Docker image:
+
+```sh
+docker run -it --rm \
+  -v /path/to/your/replays:/app/DEMOS/Input \
+  -v /path/to/your/output:/app/DEMOS/Output \
+  ghcr.io/kaszanas/sc2infoextractorgo:main [OPTIONS]
+```
+
+Alternatively, you can [compile the tool from source](#build-from-source) and run it directly on your machine.
+
+The following flags are available:
 
 ```
   -input string

--- a/replays/output/package_summary_0.json
+++ b/replays/output/package_summary_0.json
@@ -1,1 +1,0 @@
-{"Summary":{"gameVersions":{},"gameTimes":{},"maps":{},"mapGameTimes":{"gameTimes":{}},"races":{},"units":{},"otherUnits":{},"dates":{},"datesGameTimes":{"gameTimes":{}},"servers":{},"matchupCount":{},"matchupGameTimes":{"PvPMatchupGameTimes":{},"TvTMatchupGameTimes":{},"ZvZMatchupGameTimes":{},"PvZMatchupGameTimes":{},"PvTMatchupGameTimes":{},"TvZMatchupGameTimes":{}}}}

--- a/replays/output/package_summary_0.json
+++ b/replays/output/package_summary_0.json
@@ -1,0 +1,1 @@
+{"Summary":{"gameVersions":{},"gameTimes":{},"maps":{},"mapGameTimes":{"gameTimes":{}},"races":{},"units":{},"otherUnits":{},"dates":{},"datesGameTimes":{"gameTimes":{}},"servers":{},"matchupCount":{},"matchupGameTimes":{"PvPMatchupGameTimes":{},"TvTMatchupGameTimes":{},"ZvZMatchupGameTimes":{},"PvZMatchupGameTimes":{},"PvTMatchupGameTimes":{},"TvZMatchupGameTimes":{}}}}

--- a/utils/flag_utils.go
+++ b/utils/flag_utils.go
@@ -94,8 +94,5 @@ func ParseFlags() (CLIFlags, bool) {
 		LogPath:                    *logDirectoryFlag,
 	}
 
-	// flag.Usage()
-
 	return flags, true
-
 }

--- a/utils/flag_utils.go
+++ b/utils/flag_utils.go
@@ -31,8 +31,8 @@ type CLIFlags struct {
 // parseFlags contains logic which is responsible for user input.
 func ParseFlags() (CLIFlags, bool) {
 	// Command line arguments:
-	inputDirectory := flag.String("input", "./DEMOS/Input", "Input directory where .SC2Replay files are held.")
-	outputDirectory := flag.String("output", "./DEMOS/Output", "Output directory where compressed zip packages will be saved.")
+	inputDirectory := flag.String("input", "./replays/input", "Input directory where .SC2Replay files are held.")
+	outputDirectory := flag.String("output", "./replays/output", "Output directory where compressed zip packages will be saved.")
 	numberOfPackagesFlag := flag.Int("number_of_packages", 1, "Provide a number of zip packages to be created and compressed into a zip archive. Please remember that this number needs to be lower than the number of processed files. If set to 0, will ommit the zip packaging and output .json directly to drive.")
 
 	// Boolean Flags:


### PR DESCRIPTION
- Move the executable in the Dockerfile to some known location – this helps A LOT later with bind mounts, trust me.
- Use ENTRYPOINT not CMD – this way you only specify the executable to be run on startup, not the specific options.
- ~~Fix the vessel image to run the executable correctly, it seems to need libc6 for some reason. Note: this is probably not the best solution. Alpine uses musl, not libc, and the issue is probably because the compiler works with libc. Maybe switching to Alpine for compilation will fix it?~~
- Fix the vessel image by changing the builder to run on an Alpine image – otherwise we run into musl/libc compatibility errors, as explained above.
- Pin the version of the golang image to 1.21. Using `latest` for CI jobs is a very good recipe for suddenly failing pipelines :) so it's best avoided.
- Update README – running instructions.
  - Note: I didn't test the docker run command because the images are not being built now. See #52 for a suggestion on the matter. One more argument why it would be useful :) :)
  