### PR TITLE
[PR] Non Mutex Map URL Acquisition

### DIFF
--- a/dataproc/checks_filtering.go
+++ b/dataproc/checks_filtering.go
@@ -91,3 +91,12 @@ func checkNumberOfPlayers(replayData *rep.Rep, requiredNumber int) bool {
 	return numberOfPlayers == requiredNumber
 
 }
+
+// gameis1v1Ranked checks if the replay is a 1v1 ranked game.
+func gameIs1v1Ranked(replayData *rep.Rep) bool {
+
+	isAmm := replayData.InitData.GameDescription.GameOptions.Amm()
+	isCompetitive := replayData.InitData.GameDescription.GameOptions.CompetitiveOrRanked()
+	isTwoPlayers := len(replayData.Metadata.Players()) == 2
+	return isAmm && isCompetitive && isTwoPlayers
+}

--- a/dataproc/dataproc_pipeline.go
+++ b/dataproc/dataproc_pipeline.go
@@ -399,12 +399,3 @@ func FileProcessingPipeline(
 
 	return true, cleanReplayStructure, summarizedReplay, ""
 }
-
-// gameis1v1Ranked checks if the replay is a 1v1 ranked game.
-func gameIs1v1Ranked(replayData *rep.Rep) bool {
-
-	isAmm := replayData.InitData.GameDescription.GameOptions.Amm()
-	isCompetitive := replayData.InitData.GameDescription.GameOptions.CompetitiveOrRanked()
-	isTwoPlayers := len(replayData.Metadata.Players()) == 2
-	return isAmm && isCompetitive && isTwoPlayers
-}

--- a/dataproc/dataproc_pipeline.go
+++ b/dataproc/dataproc_pipeline.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc/downloader"
-	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc/sc2_map_processing"
 	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/persistent_data"
 	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/replay_data"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils"
@@ -34,114 +32,11 @@ func PipelineWrapper(
 	fileChunks [][]string,
 	packageToZipBool bool,
 	compressionMethod uint16,
-	downloadedMapsForReplaysFilepath string,
-	foreignToEnglishMappingFilepath string,
+	foreignToEnglishMapping map[string]string,
 	cliFlags utils.CLIFlags,
 ) {
 
 	log.Info("Entered PipelineWrapper()")
-	// Create maps directory if it doesn't exist:
-	err := file_utils.GetOrCreateDirectory(cliFlags.MapsDirectory)
-	if err != nil {
-		log.WithField("error", err).Error("Failed to create maps directory.")
-		return
-	}
-
-	// REVIEW: Start Review:
-	existingMapFilesSet, err := file_utils.ExistingFilesSet(
-		cliFlags.MapsDirectory, ".s2ma",
-	)
-	if err != nil {
-		log.WithField("error", err).
-			Error("Failed to get existing map files set.")
-		return
-	}
-
-	// Shared state for the downloader:
-	downloadedMapFilesSet := make(map[string]struct{})
-	downloaderSharedState, err := downloader.NewDownloaderSharedState(
-		cliFlags.MapsDirectory,
-		existingMapFilesSet,
-		downloadedMapFilesSet,
-		cliFlags.NumberOfThreads*2)
-	defer downloaderSharedState.WorkerPool.StopAndWait()
-	if err != nil {
-		log.WithField("error", err).Error("Failed to create downloader shared state.")
-		return
-	}
-
-	// STAGE ONE PRE-PROCESS:
-	// Get all map URLs into a set:
-	URLToFileNameMap, downloadedMapsForReplays, err := sc2_map_processing.
-		GetAllReplaysMapURLs(
-			fileChunks,
-			downloadedMapsForReplaysFilepath,
-			cliFlags,
-		)
-	if err != nil {
-		log.WithField("error", err).Error("Failed to get all map URLs.")
-		return
-	}
-
-	// STAGE-TWO PRE-PROCESS: Attempt downloading all SC2 maps from the read replays.
-	// Download all SC2 maps from the replays if they were not processed before:
-	existingMapFilesSet, err = DownloadAllSC2Maps(
-		&downloaderSharedState,
-		downloadedMapsForReplays,
-		downloadedMapsForReplaysFilepath,
-		URLToFileNameMap,
-		fileChunks,
-		cliFlags,
-	)
-	if err != nil {
-		log.WithField("error", err).Error("Failed to download all SC2 maps.")
-		return
-	}
-
-	// STAGE-Three PRE-PROCESS:
-	// Read all of the map names from the drive and create a mapping
-	// from foreign to english names:
-	progressBarReadLocalizedData := utils.NewProgressBar(
-		len(existingMapFilesSet),
-		"[3/4] Reading map names from drive: ",
-	)
-	mainForeignToEnglishMapping := make(map[string]string)
-	for existingMapFilepath := range existingMapFilesSet {
-
-		foreignToEnglishMapping, err := sc2_map_processing.
-			ReadLocalizedDataFromMapGetForeignToEnglishMapping(
-				existingMapFilepath,
-				progressBarReadLocalizedData,
-			)
-		if err != nil {
-			log.WithField("error", err).
-				Error("Error reading map name from drive. Map could not be processed")
-			return
-		}
-
-		// Fill out the mapping, these maps won't be opened again:
-		for foreignName, englishName := range foreignToEnglishMapping {
-			mainForeignToEnglishMapping[foreignName] = englishName
-		}
-	}
-	// Save the mapping to the drive:
-	err = sc2_map_processing.SaveForeignToEnglishMappingToDrive(
-		foreignToEnglishMappingFilepath,
-		mainForeignToEnglishMapping,
-	)
-	if err != nil {
-		log.WithField("error", err).
-			Error("Failed to save foreign to english mapping to drive.")
-		return
-	}
-
-	// REVIEW: Finish Review
-
-	// Stop all processing if the user chose to only download the maps:
-	if cliFlags.OnlyMapsDownload {
-		log.Info("Only maps download was chosen. Exiting.")
-		return
-	}
 
 	// Progress bar logic:
 	nChunks := len(fileChunks)
@@ -178,7 +73,7 @@ func PipelineWrapper(
 					packageToZipBool,
 					compressionMethod,
 					channelContents.Index,
-					mainForeignToEnglishMapping,
+					foreignToEnglishMapping,
 					progressBar,
 					cliFlags,
 				)

--- a/dataproc/dataproc_pipeline_test.go
+++ b/dataproc/dataproc_pipeline_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc/downloader"
 	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct"
 	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/persistent_data"
 	settings "github.com/Kaszanas/SC2InfoExtractorGo/settings"
@@ -166,12 +167,18 @@ func testPipelineWrapperWithDir(
 	downloadedMapsForReplaysFilepath := logFlags.LogPath + "downloaded_maps_for_replays.json"
 	foreignToEnglishMappingFilepath := logFlags.LogPath + "map_foreign_to_english_mapping.json"
 
+	foreignToEnglishMapping := downloader.MapDownloaderPipeline(
+		flags,
+		sliceOfFiles,
+		downloadedMapsForReplaysFilepath,
+		foreignToEnglishMappingFilepath,
+	)
+
 	PipelineWrapper(
 		chunksOfFiles,
 		packageToZip,
 		compressionMethod,
-		downloadedMapsForReplaysFilepath,
-		foreignToEnglishMappingFilepath,
+		foreignToEnglishMapping,
 		flags,
 	)
 

--- a/dataproc/downloader/download_all_maps.go
+++ b/dataproc/downloader/download_all_maps.go
@@ -1,9 +1,8 @@
-package dataproc
+package downloader
 
 import (
 	"net/url"
 
-	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc/downloader"
 	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/persistent_data"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils/file_utils"
@@ -13,7 +12,7 @@ import (
 // downloadAllSC2Maps download all of the maps from the replays
 // if the replays were not processed before.
 func DownloadAllSC2Maps(
-	downloaderSharedState *downloader.DownloaderSharedState,
+	downloaderSharedState *DownloaderSharedState,
 	downloadedMapsForReplays persistent_data.DownloadedMapsReplaysToFileInfo,
 	downloadedMapsForReplaysFilepath string,
 	allMapURLs map[url.URL]string,
@@ -38,7 +37,7 @@ func DownloadAllSC2Maps(
 
 		// If it wasn't, open the replay, get map information,
 		// download the map, and save it to the drive.
-		err := downloader.DownloadMapIfNotExists(
+		err := DownloadMapIfNotExists(
 			downloaderSharedState,
 			mapHashAndExtension,
 			url,

--- a/dataproc/downloader/map_downloader_pipeline.go
+++ b/dataproc/downloader/map_downloader_pipeline.go
@@ -1,0 +1,143 @@
+package downloader
+
+import (
+	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc/sc2_map_processing"
+	"github.com/Kaszanas/SC2InfoExtractorGo/utils"
+	"github.com/Kaszanas/SC2InfoExtractorGo/utils/chunk_utils"
+	"github.com/Kaszanas/SC2InfoExtractorGo/utils/file_utils"
+	log "github.com/sirupsen/logrus"
+)
+
+func MapDownloaderPipeline(
+	cliFlags utils.CLIFlags,
+	files []string,
+	downloadedMapsForReplaysFilepath string,
+	foreignToEnglishMappingFilepath string,
+) map[string]string {
+
+	// Create maps directory if it doesn't exist:
+	err := file_utils.GetOrCreateDirectory(cliFlags.MapsDirectory)
+	if err != nil {
+		log.WithField("error", err).Error("Failed to create maps directory.")
+		return nil
+	}
+
+	// REVIEW: Start Review:
+	existingMapFilesSet, err := file_utils.ExistingFilesSet(
+		cliFlags.MapsDirectory, ".s2ma",
+	)
+	if err != nil {
+		log.WithField("error", err).
+			Error("Failed to get existing map files set.")
+		return nil
+	}
+
+	// Shared state for the downloader:
+	downloadedMapFilesSet := make(map[string]struct{})
+	downloaderSharedState, err := NewDownloaderSharedState(
+		cliFlags.MapsDirectory,
+		existingMapFilesSet,
+		downloadedMapFilesSet,
+		cliFlags.NumberOfThreads*2)
+	defer downloaderSharedState.WorkerPool.StopAndWait()
+	if err != nil {
+		log.WithField("error", err).Error("Failed to create downloader shared state.")
+		return nil
+	}
+
+	// STAGE ONE PRE-PROCESS:
+	// Get all map URLs into a set:
+	URLToFileNameMap, downloadedMapsForReplays, err := sc2_map_processing.
+		GetAllReplaysMapURLs(
+			files,
+			downloadedMapsForReplaysFilepath,
+			cliFlags,
+		)
+	if err != nil {
+		log.WithField("error", err).Error("Failed to get all map URLs.")
+		return nil
+	}
+
+	// Check which of the files were previously processed and exclude them:
+	filesWithoutMaps, ok := sc2_map_processing.CheckProcessed(
+		files,
+		downloadedMapsForReplays,
+	)
+	if !ok {
+		log.Error("Failed to check which files were previously processed.")
+		return nil
+	}
+
+	// TODO: Chunk the files without maps, these are the only ones that should be
+	// processed with the downloader:
+	filesWithoutMapsChunks, ok := chunk_utils.GetChunkListAndPackageBool(
+		filesWithoutMaps,
+		cliFlags.NumberOfPackages,
+		cliFlags.NumberOfThreads,
+		len(filesWithoutMaps),
+	)
+	if !ok {
+		log.Error("Failed to get chunks for processing files for the map downloader.")
+		return nil
+	}
+
+	// TODO: Verify how to create a new main function that will be a standalone
+	// map and dependency downloader with specific exposed functions for the
+	// sc2infoextractorgo.
+
+	// STAGE-TWO PRE-PROCESS: Attempt downloading all SC2 maps from the read replays.
+	// Download all SC2 maps from the replays if they were not processed before:
+	existingMapFilesSet, err = DownloadAllSC2Maps(
+		&downloaderSharedState,
+		downloadedMapsForReplays,
+		downloadedMapsForReplaysFilepath,
+		URLToFileNameMap,
+		filesWithoutMapsChunks,
+		cliFlags,
+	)
+	if err != nil {
+		log.WithField("error", err).Error("Failed to download all SC2 maps.")
+		return nil
+	}
+
+	// STAGE-Three PRE-PROCESS:
+	// Read all of the map names from the drive and create a mapping
+	// from foreign to english names:
+	progressBarReadLocalizedData := utils.NewProgressBar(
+		len(existingMapFilesSet),
+		"[3/4] Reading map names from drive: ",
+	)
+	mainForeignToEnglishMapping := make(map[string]string)
+	for existingMapFilepath := range existingMapFilesSet {
+
+		foreignToEnglishMapping, err := sc2_map_processing.
+			ReadLocalizedDataFromMapGetForeignToEnglishMapping(
+				existingMapFilepath,
+				progressBarReadLocalizedData,
+			)
+		if err != nil {
+			log.WithField("error", err).
+				Error("Error reading map name from drive. Map could not be processed")
+			return nil
+		}
+
+		// Fill out the mapping, these maps won't be opened again:
+		for foreignName, englishName := range foreignToEnglishMapping {
+			mainForeignToEnglishMapping[foreignName] = englishName
+		}
+	}
+	// Save the mapping to the drive:
+	err = sc2_map_processing.SaveForeignToEnglishMappingToDrive(
+		foreignToEnglishMappingFilepath,
+		mainForeignToEnglishMapping,
+	)
+	if err != nil {
+		log.WithField("error", err).
+			Error("Failed to save foreign to english mapping to drive.")
+		return nil
+	}
+	return mainForeignToEnglishMapping
+
+	// REVIEW: Finish Review
+
+}

--- a/dataproc/downloader/map_downloader_pipeline.go
+++ b/dataproc/downloader/map_downloader_pipeline.go
@@ -32,19 +32,6 @@ func MapDownloaderPipeline(
 		return nil
 	}
 
-	// Shared state for the downloader:
-	downloadedMapFilesSet := make(map[string]struct{})
-	downloaderSharedState, err := NewDownloaderSharedState(
-		cliFlags.MapsDirectory,
-		existingMapFilesSet,
-		downloadedMapFilesSet,
-		cliFlags.NumberOfThreads*2)
-	defer downloaderSharedState.WorkerPool.StopAndWait()
-	if err != nil {
-		log.WithField("error", err).Error("Failed to create downloader shared state.")
-		return nil
-	}
-
 	// STAGE ONE PRE-PROCESS:
 	// Get all map URLs into a set:
 	URLToFileNameMap, downloadedMapsForReplays, err := sc2_map_processing.
@@ -87,6 +74,20 @@ func MapDownloaderPipeline(
 
 	// STAGE-TWO PRE-PROCESS: Attempt downloading all SC2 maps from the read replays.
 	// Download all SC2 maps from the replays if they were not processed before:
+
+	// Shared state for the downloader:
+	downloadedMapFilesSet := make(map[string]struct{})
+	downloaderSharedState, err := NewDownloaderSharedState(
+		cliFlags.MapsDirectory,
+		existingMapFilesSet,
+		downloadedMapFilesSet,
+		cliFlags.NumberOfThreads*2)
+	defer downloaderSharedState.WorkerPool.StopAndWait()
+	if err != nil {
+		log.WithField("error", err).Error("Failed to create downloader shared state.")
+		return nil
+	}
+
 	existingMapFilesSet, err = DownloadAllSC2Maps(
 		&downloaderSharedState,
 		downloadedMapsForReplays,

--- a/dataproc/sc2_map_processing/check_processed.go
+++ b/dataproc/sc2_map_processing/check_processed.go
@@ -1,0 +1,55 @@
+package sc2_map_processing
+
+import (
+	"os"
+
+	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/persistent_data"
+	log "github.com/sirupsen/logrus"
+)
+
+func CheckProcessed(
+	files []string,
+	processedFiles persistent_data.DownloadedMapsReplaysToFileInfo,
+) ([]string, bool) {
+
+	filteredFilesToProcess := []string{}
+	alreadyProcessedFiles := processedFiles.DownloadedMapsForFiles
+
+	for _, file := range files {
+
+		// TODO: This logic should be moved before getting the list of all files:
+		// Check if the replay was already processed:
+		fileInfo, err := os.Stat(file)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":      err,
+				"replayFile": file,
+			}).Error("Failed to get file info.")
+			return []string{}, false
+		}
+
+		// If the file was already processed, and was not modified since,
+		// then it will be skipped from getting the map URL:
+		fileInfoToCheck, alreadyProcessed := alreadyProcessedFiles[file]
+		if alreadyProcessed {
+			// Check if the file was modified since the last time it was processed:
+			if persistent_data.CheckFileInfoEq(
+				fileInfo,
+				fileInfoToCheck.(persistent_data.FileInformationToCheck),
+			) {
+				// It is the same so continue
+				log.WithField("file", file).
+					Warning("This replay was already processed, map should be available, continuing!")
+				continue
+			}
+			// It wasn't the same so the replay should be processed again:
+			log.WithField("file", file).
+				Warn("Replay was modified since the last time it was processed! Processing again.")
+
+			filteredFilesToProcess = append(filteredFilesToProcess, file)
+
+		}
+	}
+
+	return filteredFilesToProcess, true
+}

--- a/datastruct/persistent_data/processed_replays.go
+++ b/datastruct/persistent_data/processed_replays.go
@@ -48,7 +48,7 @@ func OpenOrCreateDownloadedMapsForReplaysToFileInfo(
 		return DownloadedMapsReplaysToFileInfo{}, replaysToProcess, err
 	}
 
-	prtm := DownloadedMapsReplaysToFileInfo{
+	alreadyProcessed := DownloadedMapsReplaysToFileInfo{
 		DownloadedMapsForFiles: mapToPopulateFromPersistentJSON,
 	}
 
@@ -61,7 +61,7 @@ func OpenOrCreateDownloadedMapsForReplaysToFileInfo(
 			}).Error("Failed to get file info.")
 			return DownloadedMapsReplaysToFileInfo{}, replaysToProcess, err
 		}
-		fileInfoToCheck, ok := prtm.CheckIfReplayWasProcessed(replayFile)
+		fileInfoToCheck, ok := alreadyProcessed.CheckIfReplayWasProcessed(replayFile)
 		// Replay was processed so no need to check it again:
 		if ok {
 			// Check if the file was modified since the last time it was processed:
@@ -72,10 +72,10 @@ func OpenOrCreateDownloadedMapsForReplaysToFileInfo(
 		}
 		// It wasn't the same so the replay should be processed again:
 		replaysToProcess = append(replaysToProcess, replayFile)
-		delete(prtm.DownloadedMapsForFiles, replayFile)
+		delete(alreadyProcessed.DownloadedMapsForFiles, replayFile)
 	}
 
-	return prtm, replaysToProcess, nil
+	return alreadyProcessed, replaysToProcess, nil
 }
 
 // CheckFileInfoEq compares the fs.FileInfo contents with FileInfoToCheck.

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"runtime/pprof"
 
 	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc"
+	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/persistent_data"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils/chunk_utils"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils/file_utils"
@@ -88,6 +89,13 @@ func mainReturnWithCode() int {
 			"Higher number of packages than input files, closing the program.")
 		return 1
 	}
+
+	// Check which of the files were previously processed and exclude them
+	// from chunking.
+	persistent_data.OpenOrCreateDownloadedMapsForReplaysToFileInfo()
+	// for _, replayFile := range listOfInputFiles {
+
+	// }
 
 	listOfChunksFiles, packageToZipBool := chunk_utils.GetChunkListAndPackageBool(
 		listOfInputFiles,

--- a/main.go
+++ b/main.go
@@ -5,7 +5,8 @@ import (
 	"runtime/pprof"
 
 	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc"
-	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/persistent_data"
+	"github.com/Kaszanas/SC2InfoExtractorGo/dataproc/downloader"
+
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils/chunk_utils"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils/file_utils"
@@ -90,12 +91,17 @@ func mainReturnWithCode() int {
 		return 1
 	}
 
-	// Check which of the files were previously processed and exclude them
-	// from chunking.
-	persistent_data.OpenOrCreateDownloadedMapsForReplaysToFileInfo()
-	// for _, replayFile := range listOfInputFiles {
-
-	// }
+	// Downloading the maps for the files:
+	foreignToEnglishMapping := downloader.MapDownloaderPipeline(
+		CLIflags,
+		listOfInputFiles,
+		downloadedMapsForReplaysFilepath,
+		foreignToEnglishMappingFilepath,
+	)
+	if CLIflags.OnlyMapsDownload {
+		log.Info("Only maps download was chosen. Exiting.")
+		return 0
+	}
 
 	listOfChunksFiles, packageToZipBool := chunk_utils.GetChunkListAndPackageBool(
 		listOfInputFiles,
@@ -111,8 +117,7 @@ func mainReturnWithCode() int {
 		listOfChunksFiles,
 		packageToZipBool,
 		compressionMethod,
-		downloadedMapsForReplaysFilepath,
-		foreignToEnglishMappingFilepath,
+		foreignToEnglishMapping,
 		CLIflags,
 	)
 


### PR DESCRIPTION
## Description

Before these changes, there were multiple `sync.Map` data structure used within multiple goroutines. This was not needed, and was removed and replaced by processing that returns its output through the `outputChannel`. After that the calling function has the ability to handle duplicates when creating final mapping from the URL to filenames.