### PR TITLE
[PR] Simplified Downloading Pipeline

### DIFF
--- a/dataproc/dataproc_pipeline_test.go
+++ b/dataproc/dataproc_pipeline_test.go
@@ -130,7 +130,7 @@ func testPipelineWrapperWithDir(
 		return false, "Could not get the list of files."
 	}
 
-	chunksOfFiles, getOk := chunk_utils.GetChunksOfFiles(sliceOfFiles, 0)
+	chunksOfFiles, getOk := chunk_utils.GetChunks(sliceOfFiles, 0)
 	if !getOk {
 		return false, "Could not produce chunks of files!"
 	}
@@ -164,14 +164,12 @@ func testPipelineWrapperWithDir(
 	compressionMethod := uint16(8)
 
 	// Auxiliary files will be placed in the same directory as the log file:
-	downloadedMapsForReplaysFilepath := logFlags.LogPath + "downloaded_maps_for_replays.json"
 	foreignToEnglishMappingFilepath := logFlags.LogPath + "map_foreign_to_english_mapping.json"
 
 	foreignToEnglishMapping := downloader.MapDownloaderPipeline(
-		flags,
 		sliceOfFiles,
-		downloadedMapsForReplaysFilepath,
 		foreignToEnglishMappingFilepath,
+		flags,
 	)
 
 	PipelineWrapper(
@@ -263,7 +261,8 @@ func pipelineTestCleanup(
 	testOutputPath string,
 	logFile *os.File,
 	deleteOutputDir bool,
-	deleteLogsFilepath bool) (string, error) {
+	deleteLogsFilepath bool,
+) (string, error) {
 
 	// err := os.Remove(processedFailedPath)
 	// if err != nil {

--- a/dataproc/downloader/download_all_maps.go
+++ b/dataproc/downloader/download_all_maps.go
@@ -3,9 +3,7 @@ package downloader
 import (
 	"net/url"
 
-	"github.com/Kaszanas/SC2InfoExtractorGo/datastruct/persistent_data"
 	"github.com/Kaszanas/SC2InfoExtractorGo/utils"
-	"github.com/Kaszanas/SC2InfoExtractorGo/utils/file_utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -13,29 +11,26 @@ import (
 // if the replays were not processed before.
 func DownloadAllSC2Maps(
 	downloaderSharedState *DownloaderSharedState,
-	downloadedMapsForReplays persistent_data.DownloadedMapsReplaysToFileInfo,
-	downloadedMapsForReplaysFilepath string,
-	allMapURLs map[url.URL]string,
-	fileChunks [][]string,
+	URLsToDownload map[url.URL]string,
 	cliFlags utils.CLIFlags,
-) (map[string]struct{}, error) {
+) error {
 
 	log.WithFields(log.Fields{
-		"mapsDirectory":              cliFlags.MapsDirectory,
-		"n_downloadedMapsForReplays": len(downloadedMapsForReplays.DownloadedMapsForFiles)}).
+		"mapsDirectory": cliFlags.MapsDirectory}).
 		Info("Entered downloadAllSC2Maps()")
 
 	defer downloaderSharedState.WorkerPool.StopAndWait()
 
 	// Progress bar:
 	progressBarDownloadMaps := utils.NewProgressBar(
-		len(allMapURLs),
+		len(URLsToDownload),
 		"[2/4] Downloading maps: ",
 	)
 	defer progressBarDownloadMaps.Close()
-	for url, mapHashAndExtension := range allMapURLs {
+	for url, mapHashAndExtension := range URLsToDownload {
 
-		// If it wasn't, open the replay, get map information,
+		// If the replay was not processed previosly,
+		// open the replay, get map information,
 		// download the map, and save it to the drive.
 		err := DownloadMapIfNotExists(
 			downloaderSharedState,
@@ -55,28 +50,5 @@ func DownloadAllSC2Maps(
 	downloaderSharedState.WorkerPool.StopAndWait()
 	progressBarDownloadMaps.Close()
 
-	// Save the processed replays to the file:
-	err := downloadedMapsForReplays.SaveDownloadedMapsForReplaysFile(
-		downloadedMapsForReplaysFilepath,
-	)
-	if err != nil {
-		log.WithField("downloadedMapsForReplaysFile",
-			downloadedMapsForReplaysFilepath,
-		).
-			Error("Failed to save the processed replays file.")
-		return nil, err
-	}
-
-	// Get the list of maps after the download finishes:
-	existingMapFilesSet, err := file_utils.ExistingFilesSet(
-		cliFlags.MapsDirectory,
-		".s2ma",
-	)
-	if err != nil {
-		log.WithField("mapsDirectory", cliFlags.MapsDirectory).
-			Error("Failed to get the set of existing map files.")
-		return nil, err
-	}
-
-	return existingMapFilesSet, nil
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -39,7 +39,6 @@ func mainReturnWithCode() int {
 	}
 
 	// Auxiliary files will be placed in the same directory as the log file:
-	downloadedMapsForReplaysFilepath := CLIflags.LogFlags.LogPath + "downloaded_maps_for_replays.json"
 	foreignToEnglishMappingFilepath := CLIflags.LogFlags.LogPath + "map_foreign_to_english_mapping.json"
 
 	log.WithFields(log.Fields{
@@ -93,10 +92,9 @@ func mainReturnWithCode() int {
 
 	// Downloading the maps for the files:
 	foreignToEnglishMapping := downloader.MapDownloaderPipeline(
-		CLIflags,
 		listOfInputFiles,
-		downloadedMapsForReplaysFilepath,
 		foreignToEnglishMappingFilepath,
+		CLIflags,
 	)
 	if CLIflags.OnlyMapsDownload {
 		log.Info("Only maps download was chosen. Exiting.")

--- a/test_utils/test_setup.go
+++ b/test_utils/test_setup.go
@@ -67,7 +67,7 @@ func SetTestCLIFlags(t *testing.T) (
 	}
 	log.WithField("n_files", len(sliceOfFiles)).Info("Number of detected files.")
 
-	chunks, getOk := chunk_utils.GetChunksOfFiles(sliceOfFiles, 0)
+	chunks, getOk := chunk_utils.GetChunks(sliceOfFiles, 0)
 	if !getOk {
 		t.Fatalf("Test Failed! Could not produce chunks of files!")
 	}

--- a/utils/chunk_utils/chunk_utils.go
+++ b/utils/chunk_utils/chunk_utils.go
@@ -7,19 +7,19 @@ import (
 )
 
 // GetChunksOfFiles returns chunks of files for processing.
-func GetChunksOfFiles(slice []string, chunkSize int) ([][]string, bool) {
-
-	log.Info("Entered chunkSlice()")
+// GetChunks returns chunks of any type for processing.
+func GetChunks[T any](slice []T, chunkSize int) ([][]T, bool) {
+	log.Info("Entered GetChunks()")
 
 	if chunkSize < 0 {
-		return [][]string{}, false
+		return [][]T{}, false
 	}
 
 	if chunkSize == 0 {
-		return [][]string{slice}, true
+		return [][]T{slice}, true
 	}
 
-	var chunks [][]string
+	var chunks [][]T
 	for i := 0; i < len(slice); i += chunkSize {
 		end := i + chunkSize
 
@@ -31,18 +31,18 @@ func GetChunksOfFiles(slice []string, chunkSize int) ([][]string, bool) {
 		chunks = append(chunks, slice[i:end])
 	}
 
-	log.Info("Finished chunkSlice(), returning")
+	log.Info("Finished GetChunks(), returning")
 	return chunks, true
 }
 
 // GetChunkListAndPackageBool returns list of chunks of files that
 // will be processed and a boolean specifying if the chunking process was a success.
-func GetChunkListAndPackageBool(
-	listOfInputFiles []string,
+func GetChunkListAndPackageBool[T any](
+	listOfInputs []T,
 	numberOfPackages int,
 	numberOfThreads int,
 	lenListOfInputFiles int,
-) ([][]string, bool) {
+) ([][]T, bool) {
 
 	log.Info("Entered getChunkListAndPackageBool()")
 
@@ -57,15 +57,14 @@ func GetChunkListAndPackageBool(
 		// specified number of packages.
 		// Number of chunks is n_files/n_user_provided_packages
 		numberOfFilesInPackage = int(math.Ceil(float64(lenListOfInputFiles) / float64(numberOfPackages)))
-		listOfChunksFiles, _ := GetChunksOfFiles(listOfInputFiles, numberOfFilesInPackage)
+		listOfChunksFiles, _ := GetChunks(listOfInputs, numberOfFilesInPackage)
 		return listOfChunksFiles, packageToZipBool
 	}
 
 	// If we write stringified .json files of replays to drive without
 	// packaging the number of chunks will be n_files/n_threads
 	numberOfFilesInPackage = int(math.Ceil(float64(lenListOfInputFiles) / float64(numberOfThreads)))
-	listOfChunksFiles, _ := GetChunksOfFiles(listOfInputFiles, numberOfFilesInPackage)
+	listOfChunksFiles, _ := GetChunks(listOfInputs, numberOfFilesInPackage)
 
 	return listOfChunksFiles, packageToZipBool
-
 }

--- a/utils/chunk_utils/chunk_utils_test.go
+++ b/utils/chunk_utils/chunk_utils_test.go
@@ -10,7 +10,7 @@ func TestGetChunksOfFilesZero(t *testing.T) {
 
 	// Read all the test input directory:
 	sliceOfFiles := []string{"test_file.txt"}
-	sliceOfChunks, getOk := GetChunksOfFiles(sliceOfFiles, 0)
+	sliceOfChunks, getOk := GetChunks(sliceOfFiles, 0)
 
 	if !getOk {
 		t.Fatalf("Test Failed! getChunksOfFiles() returned getOk = false.")
@@ -28,7 +28,7 @@ func TestGetChunksOfFilesMinus(t *testing.T) {
 
 	// Read all the test input directory:
 	sliceOfFiles := []string{"test_file.txt"}
-	_, getOk := GetChunksOfFiles(sliceOfFiles, -1)
+	_, getOk := GetChunks(sliceOfFiles, -1)
 
 	if getOk {
 		t.Fatalf("Test Failed! getChunksOfFiles() returned getOk = true.")

--- a/utils/file_utils/path_utils_test.go
+++ b/utils/file_utils/path_utils_test.go
@@ -19,7 +19,7 @@ func TestGetChunksOfFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test Failed! Couldn't get the list of files.")
 	}
-	sliceOfChunks, getOk := chunk_utils.GetChunksOfFiles(sliceOfFiles, 1)
+	sliceOfChunks, getOk := chunk_utils.GetChunks(sliceOfFiles, 1)
 	if !getOk {
 		t.Fatalf("Test Failed! getChunksOfFiles() returned getOk = false.")
 	}


### PR DESCRIPTION
No more persistence checks to verify if the replay was processed, all of the replay files that are passed as input will be read.

Maps will not be downloaded as long as there is a valid map file (that can be opened) on disk.