### PR TITLE
[PR] Preparing release 2.1.1 (Hotfix)

### DIFF
--- a/dataproc/clean_replay.go
+++ b/dataproc/clean_replay.go
@@ -14,7 +14,8 @@ import (
 func extractReplayData(
 	replayData *rep.Rep,
 	englishToForeignMapping map[string]string,
-	performCleanupBool bool) (bool, replay_data.CleanedReplay) {
+	performCleanupBool bool,
+) (bool, replay_data.CleanedReplay) {
 
 	log.Debug("Entered cleanReplay()")
 

--- a/dataproc/dataproc_pipeline_test.go
+++ b/dataproc/dataproc_pipeline_test.go
@@ -65,7 +65,7 @@ func TestPipelineWrapperMultiple(t *testing.T) {
 					if _, err := os.Stat(thisTestOutputDir); os.IsNotExist(err) {
 						log.WithField("thisTestOutputDir", thisTestOutputDir).
 							Info("Test output dir does not exist, attempting to create.")
-						err = os.Mkdir(thisTestOutputDir, 0755)
+						err = os.MkdirAll(thisTestOutputDir, 0755)
 						if err != nil {
 							t.Fatal("Test Failed! Could not create output directory for test!")
 						}

--- a/dataproc/downloader/map_downloader_pipeline.go
+++ b/dataproc/downloader/map_downloader_pipeline.go
@@ -143,9 +143,11 @@ func readMapNamesFromMapFiles(
 				progressBarReadLocalizedData,
 			)
 		if err != nil {
-			log.WithField("error", err).
-				Error("Error reading map name from drive. Map could not be processed")
-			return nil
+			log.WithFields(log.Fields{
+				"error":               err,
+				"existingMapFilepath": existingMapFilepath,
+			}).Error("Error reading map name from drive. Map could not be processed")
+			continue
 		}
 
 		// Fill out the mapping, these maps won't be opened again:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.3
 require (
 	github.com/alitto/pond v1.9.2
 	github.com/icza/mpq v0.0.0-20230330132843-d3cdc0b651b7
-	github.com/icza/s2prot v1.5.2
+	github.com/icza/s2prot v1.5.2-0.20241207072335-d0e305d1c9c8
 	github.com/joho/godotenv v1.5.1
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/icza/mpq v0.0.0-20170726141842-266342679beb/go.mod h1:iWOw+dZSITjPKFPiCNT7QE+xENOlT/YrBtMYkImipFo=
 github.com/icza/mpq v0.0.0-20230330132843-d3cdc0b651b7 h1:uWfnpztXMlK2068Uuv23eGsFsQpORS0UxYosbhPCMsI=
 github.com/icza/mpq v0.0.0-20230330132843-d3cdc0b651b7/go.mod h1:uZjJdSdZs2x2Gq+6/NdJE7nJ1upyftiNnw1ZMCFH+tc=
+github.com/icza/s2prot v1.5.2-0.20241207072335-d0e305d1c9c8 h1:dX42iKZ/pURGBBb/f2CXjwAseqP4UKre/jiUPFz+1UU=
+github.com/icza/s2prot v1.5.2-0.20241207072335-d0e305d1c9c8/go.mod h1:Aw3BgGOZ83Qkxmz90i22WFCMiDU4oOFT5D3hoDLBl3E=
 github.com/icza/s2prot v1.5.2 h1:lc24kcR0FcUlHPB8l7qmJ4zeEJDKYgTacr/oCD66h+w=
 github.com/icza/s2prot v1.5.2/go.mod h1:Aw3BgGOZ83Qkxmz90i22WFCMiDU4oOFT5D3hoDLBl3E=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/utils/file_utils/create_file_utils.go
+++ b/utils/file_utils/create_file_utils.go
@@ -74,7 +74,7 @@ func GetOrCreateDirectory(pathToMapsDirectory string) error {
 	log.Debug("Entered CreateMapsDirectory()")
 
 	// Create the maps directory:
-	err := os.Mkdir(pathToMapsDirectory, 0777)
+	err := os.MkdirAll(pathToMapsDirectory, 0777)
 	if os.IsExist(err) {
 		log.Info("The maps directory already exists!")
 		return nil

--- a/utils/logging_utils.go
+++ b/utils/logging_utils.go
@@ -19,7 +19,7 @@ func SetLogging(logPath string, logLevel int) (*os.File, bool) {
 		log.WithField("error", err).
 			Warn("Log directory does not exist. Creating it.")
 
-		err := os.Mkdir(logDirectoryString, 0755)
+		err := os.MkdirAll(logDirectoryString, 0755)
 		if err != nil {
 			log.WithField("error", err).Fatal("Cannot create log directory.")
 			return &os.File{}, false

--- a/utils/logging_utils.go
+++ b/utils/logging_utils.go
@@ -12,6 +12,7 @@ func SetLogging(logPath string, logLevel int) (*os.File, bool) {
 
 	logDirectoryString := logPath
 	log.SetFormatter(&log.JSONFormatter{})
+	log.SetReportCaller(true)
 
 	// Check if the directory exists:
 	if _, err := os.Stat(logDirectoryString); os.IsNotExist(err) {

--- a/utils/logging_utils.go
+++ b/utils/logging_utils.go
@@ -16,9 +16,12 @@ func SetLogging(logPath string, logLevel int) (*os.File, bool) {
 
 	// Check if the directory exists:
 	if _, err := os.Stat(logDirectoryString); os.IsNotExist(err) {
+		log.WithField("error", err).
+			Warn("Log directory does not exist. Creating it.")
+
 		err := os.Mkdir(logDirectoryString, 0755)
 		if err != nil {
-			log.Fatal(err)
+			log.WithField("error", err).Fatal("Cannot create log directory.")
 			return &os.File{}, false
 		}
 	}


### PR DESCRIPTION
In case when the map file is not readable the pipeline will continue reading all other map names. Previously the early return meant that all other functions would be executed with partially initialized foreign to english map structure.